### PR TITLE
chore: detect UI errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-src export-ignore

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,9 @@
 local QBCore = exports['qb-core']:GetCoreObject()
+
+if not LoadResourceFile("Renewed-Banking", 'web/public/build/bundle.js') then
+    error('Unable to load UI. Build Renewed-Banking or download the latest release.\n   ^https://github.com/Renewed-Scripts/Renewed-Banking/releases/latest/download/Renewed-Banking.rar^0\n    If you are using a custom build of the UI, please make sure the resource name is Renewed-Banking (you may not rename the resource).')
+end
+
 local cachedAccounts = {}
 local cachedPlayers = {}
 


### PR DESCRIPTION
Detects if 1. The person downloaded the source code instead of the release and provides a direct link to the latest `.rar` release file. 2. The person potentially renamed the resource, also provides a message telling them not to do that.