### PR TITLE
refactor(server/main): proper return for SQL insertion

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -607,7 +607,7 @@ local function CreateJobAccount(job, initialBalance)
         creator = nil
     }
 
-    local success, errorMsg = MySQL.insert("INSERT INTO bank_accounts_new (id, amount, transactions, auth, isFrozen, creator) VALUES (?, ?, ?, ?, ?, NULL)", {
+    local insertId = MySQL.insert.await("INSERT INTO bank_accounts_new (id, amount, transactions, auth, isFrozen, creator) VALUES (?, ?, ?, ?, ?, NULL)", {
         job.name,
         cachedAccounts[job.name].amount,
         json.encode(cachedAccounts[job.name].transactions), -- Convert transactions to JSON
@@ -616,9 +616,9 @@ local function CreateJobAccount(job, initialBalance)
     })
 
     -- Handle potential database errors
-    if not success then
+    if not insertId then
 	cachedAccounts[job.name] = nil
-        error(("^5[%s]^7-^1[ERROR]^7 %s"):format(currentResourceName, "Database error: " .. tostring(errorMsg)))
+        error(("^5[%s]^7-^1[ERROR]^7 %s"):format(currentResourceName, "Database error"))
     end
 
     return cachedAccounts[job.name]


### PR DESCRIPTION
Earlier success would always return nil, because MySQL.Insert doesnt return anything. This is now fixed.