### PR TITLE
feat: format amount input with comma separators (e.g. 1,000,000)

### DIFF
--- a/web/src/components/Popup.svelte
+++ b/web/src/components/Popup.svelte
@@ -1,10 +1,45 @@
 <script lang="ts">
+    import { tick } from "svelte";
     import { accounts, activeAccount, popupDetails, loading, translations } from "../store/stores";
     import {fetchNui} from "../utils/fetchNui"
     let amount: number = 0;
+    let displayAmount: string = "";
+    let amountInput: HTMLInputElement;
+    let cursorInfo: { digitsBefore: number; formattedValue: string } | null = null;
     let comment: string = "";
     let stateid: string = "";
     $: account = $accounts.find((accountItem: any) => $activeAccount === accountItem.id);
+
+    function handleAmountInput(event: Event) {
+        const el = event.target as HTMLInputElement;
+        const rawValue = el.value;
+        const selectionStart = el.selectionStart ?? 0;
+        const beforeCursor = rawValue.substring(0, selectionStart);
+        const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
+        const digits = rawValue.replace(/[^0-9]/g, "");
+        if (digits === "") {
+            displayAmount = "";
+            amount = 0;
+            return;
+        }
+        const formatted = Number(digits).toLocaleString('en-us');
+        const digitsBeforeCursor = selectionStart - commaCountBefore;
+        displayAmount = formatted;
+        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
+        amount = Math.floor(Math.max(0, Number(digits)));
+        tick().then(() => {
+            if (amountInput && cursorInfo !== null) {
+                const { digitsBefore, formattedValue } = cursorInfo;
+                let newPos = 0;
+                let count = 0;
+                for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
+                    if (/[0-9]/.test(formattedValue[i])) count++;
+                    newPos++;
+                }
+                amountInput.setSelectionRange(newPos, newPos);
+            }
+        });
+    }
 
     function closePopup() {
         popupDetails.update((val: any) => ({
@@ -33,7 +68,7 @@
         <form action="#">
             <div class="form-row">
                 <label for="amount">{$translations.amount}</label>
-                <input bind:value={amount} type="number" name="amount" id="amount" placeholder="$" />
+                <input bind:this={amountInput} value={displayAmount} on:input={handleAmountInput} type="text" name="amount" id="amount" placeholder="$" />
             </div>
 
             <div class="form-row">

--- a/web/src/components/Popup.svelte
+++ b/web/src/components/Popup.svelte
@@ -10,35 +10,68 @@
     let stateid: string = "";
     $: account = $accounts.find((accountItem: any) => $activeAccount === accountItem.id);
 
+    function restoreCursor() {
+        if (amountInput && cursorInfo !== null) {
+            const { digitsBefore, formattedValue } = cursorInfo;
+            let newPos = 0;
+            let count = 0;
+            for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
+                if (/[0-9]/.test(formattedValue[i])) count++;
+                newPos++;
+            }
+            amountInput.setSelectionRange(newPos, newPos);
+        }
+    }
+
+    function applyAmount(rawValue: string, rawCursorPos: number) {
+        const digits = rawValue.replace(/[^0-9]/g, "");
+        if (digits === "") {
+            displayAmount = "";
+            amount = 0;
+            tick().then(() => amountInput?.setSelectionRange(0, 0));
+            return;
+        }
+        const formatted = Number(digits).toLocaleString('en-us');
+        const beforeCursor = rawValue.substring(0, rawCursorPos);
+        const digitsBeforeCursor = (beforeCursor.match(/[0-9]/g) || []).length;
+        displayAmount = formatted;
+        amount = Math.floor(Math.max(0, Number(digits)));
+        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
+        tick().then(() => restoreCursor());
+    }
+
+    function handleAmountKeydown(event: KeyboardEvent) {
+        const el = event.target as HTMLInputElement;
+        const pos = el.selectionStart ?? 0;
+        const val = el.value;
+        if (event.key === "Backspace" && pos > 0 && val[pos - 1] === ",") {
+            event.preventDefault();
+            const newVal = val.slice(0, pos - 2) + val.slice(pos);
+            applyAmount(newVal, pos - 2);
+        } else if (event.key === "Delete" && pos < val.length && val[pos] === ",") {
+            event.preventDefault();
+            const newVal = val.slice(0, pos) + val.slice(pos + 2);
+            applyAmount(newVal, pos);
+        }
+    }
+
     function handleAmountInput(event: Event) {
         const el = event.target as HTMLInputElement;
-        const rawValue = el.value;
         const selectionStart = el.selectionStart ?? 0;
-        const beforeCursor = rawValue.substring(0, selectionStart);
+        const beforeCursor = el.value.substring(0, selectionStart);
         const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
-        const digits = rawValue.replace(/[^0-9]/g, "");
+        const digitsBeforeCursor = selectionStart - commaCountBefore;
+        const digits = el.value.replace(/[^0-9]/g, "");
         if (digits === "") {
             displayAmount = "";
             amount = 0;
             return;
         }
         const formatted = Number(digits).toLocaleString('en-us');
-        const digitsBeforeCursor = selectionStart - commaCountBefore;
         displayAmount = formatted;
-        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
         amount = Math.floor(Math.max(0, Number(digits)));
-        tick().then(() => {
-            if (amountInput && cursorInfo !== null) {
-                const { digitsBefore, formattedValue } = cursorInfo;
-                let newPos = 0;
-                let count = 0;
-                for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
-                    if (/[0-9]/.test(formattedValue[i])) count++;
-                    newPos++;
-                }
-                amountInput.setSelectionRange(newPos, newPos);
-            }
-        });
+        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
+        tick().then(() => restoreCursor());
     }
 
     function closePopup() {
@@ -68,7 +101,7 @@
         <form action="#">
             <div class="form-row">
                 <label for="amount">{$translations.amount}</label>
-                <input bind:this={amountInput} value={displayAmount} on:input={handleAmountInput} type="text" name="amount" id="amount" placeholder="$" />
+                <input bind:this={amountInput} value={displayAmount} on:keydown={handleAmountKeydown} on:input={handleAmountInput} type="text" name="amount" id="amount" placeholder="$" />
             </div>
 
             <div class="form-row">

--- a/web/src/components/Popup.svelte
+++ b/web/src/components/Popup.svelte
@@ -5,73 +5,51 @@
     let amount: number = 0;
     let displayAmount: string = "";
     let amountInput: HTMLInputElement;
-    let cursorInfo: { digitsBefore: number; formattedValue: string } | null = null;
+    let cursorDigits: number | null = null;
     let comment: string = "";
     let stateid: string = "";
     $: account = $accounts.find((accountItem: any) => $activeAccount === accountItem.id);
 
-    function restoreCursor() {
-        if (amountInput && cursorInfo !== null) {
-            const { digitsBefore, formattedValue } = cursorInfo;
-            let newPos = 0;
-            let count = 0;
-            for (let i = 0; i < formattedValue.length && count < digitsBefore; i++) {
-                if (/[0-9]/.test(formattedValue[i])) count++;
-                newPos++;
-            }
-            amountInput.setSelectionRange(newPos, newPos);
-        }
+    const digitsOnly = (s: string) => s.replace(/\D/g, '');
+    const countDigitsBefore = (s: string, index: number) => digitsOnly(s.substring(0, index)).length;
+    const formatAmount = (n: number) => (n ? n.toLocaleString('en-US') : '');
+
+    function commitAmount(raw: string, cursorIndex: number) {
+        const num = parseInt(digitsOnly(raw), 10) || 0;
+        displayAmount = formatAmount(num);
+        amount = num;
+        cursorDigits = countDigitsBefore(raw, cursorIndex);
+        tick().then(() => restoreCursor());
     }
 
-    function applyAmount(rawValue: string, rawCursorPos: number) {
-        const digits = rawValue.replace(/[^0-9]/g, "");
-        if (digits === "") {
-            displayAmount = "";
-            amount = 0;
-            tick().then(() => amountInput?.setSelectionRange(0, 0));
-            return;
+    function restoreCursor() {
+        if (!amountInput || cursorDigits === null) return;
+        let newPos = 0;
+        let count = 0;
+        for (let i = 0; i < displayAmount.length && count < cursorDigits; i++) {
+            if (/\d/.test(displayAmount[i])) count++;
+            newPos++;
         }
-        const formatted = Number(digits).toLocaleString('en-us');
-        const beforeCursor = rawValue.substring(0, rawCursorPos);
-        const digitsBeforeCursor = (beforeCursor.match(/[0-9]/g) || []).length;
-        displayAmount = formatted;
-        amount = Math.floor(Math.max(0, Number(digits)));
-        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
-        tick().then(() => restoreCursor());
+        amountInput.setSelectionRange(newPos, newPos);
+        cursorDigits = null;
     }
 
     function handleAmountKeydown(event: KeyboardEvent) {
         const el = event.target as HTMLInputElement;
         const pos = el.selectionStart ?? 0;
-        const val = el.value;
-        if (event.key === "Backspace" && pos > 0 && val[pos - 1] === ",") {
+        if (pos !== el.selectionEnd) return;
+        if (event.key === "Backspace" && el.value[pos - 1] === ",") {
             event.preventDefault();
-            const newVal = val.slice(0, pos - 2) + val.slice(pos);
-            applyAmount(newVal, pos - 2);
-        } else if (event.key === "Delete" && pos < val.length && val[pos] === ",") {
+            commitAmount(el.value.slice(0, pos - 2) + el.value.slice(pos), pos - 2);
+        } else if (event.key === "Delete" && el.value[pos] === ",") {
             event.preventDefault();
-            const newVal = val.slice(0, pos) + val.slice(pos + 2);
-            applyAmount(newVal, pos);
+            commitAmount(el.value.slice(0, pos) + el.value.slice(pos + 2), pos);
         }
     }
 
     function handleAmountInput(event: Event) {
         const el = event.target as HTMLInputElement;
-        const selectionStart = el.selectionStart ?? 0;
-        const beforeCursor = el.value.substring(0, selectionStart);
-        const commaCountBefore = (beforeCursor.match(/[^0-9]/g) || []).length;
-        const digitsBeforeCursor = selectionStart - commaCountBefore;
-        const digits = el.value.replace(/[^0-9]/g, "");
-        if (digits === "") {
-            displayAmount = "";
-            amount = 0;
-            return;
-        }
-        const formatted = Number(digits).toLocaleString('en-us');
-        displayAmount = formatted;
-        amount = Math.floor(Math.max(0, Number(digits)));
-        cursorInfo = { digitsBefore: digitsBeforeCursor, formattedValue: formatted };
-        tick().then(() => restoreCursor());
+        commitAmount(el.value, el.selectionStart ?? 0);
     }
 
     function closePopup() {


### PR DESCRIPTION
## Summary

Amount input field now formats numbers with comma separators as you type (e.g. `1000000` → `1,000,000`).

## Changes

- Changed amount `<input>` from `type="number"` to `type="text"`
- Applied `toLocaleString('en-us')` formatting on each keystroke
- Preserved cursor position after formatting using Svelte's `tick()`
- Actual numeric value is still stored separately and sent to the server as-is

## Demo

![Renewed-Banking](https://github.com/user-attachments/assets/f214c7c8-f3db-49ab-9eec-e92c0cad0ae7)

## Notes

- Commas are display-only and do not affect the submitted value